### PR TITLE
Add support for multiple models (space-separated)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: ./
         with:
-          model: qwen:0.5b
+          model: qwen:0.5b qwen3:0.6b
           cache-key: v2
 
       - run: ollama list

--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ We can then run tests and connect to `http://localhost:11434` to make requests t
 
 This action is used by [`pydantic-ai`](https://github.com/pydantic/pydantic-ai).
 
+You can also pull multiple models by specifying space separated models names:
+
+```yaml
+      - uses: pydantic/ollama-action@v3
+        with:
+          model: qwen2:0.5b llama3.2
+```
+

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   model:
-    description: The model to run
+    description: The models to run space-separated (e.g. 'llama3.2 qwen3:4b')
     required: true
   cache-key:
     description: The cache key to use
@@ -27,7 +27,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.ollama
-        key: ollama-models-${{ inputs.cache-key }}-${{ inputs.model }}
+        key: ollama-models-${{ inputs.cache-key }}
 
     - if: steps.cache-ollama-install.outputs.cache-hit != 'true'
       run: '${GITHUB_ACTION_PATH}/install-ollama.sh'
@@ -42,6 +42,13 @@ runs:
     - run: ollama --version
       shell: bash
 
-    - if: steps.cache-ollama-models.outputs.cache-hit != 'true'
-      run: ollama pull ${{ inputs.model }}
+    - run: |
+        for model in ${{ inputs.model }}; do
+          if ! ollama list | grep -q "$model"; then
+            echo "Pulling missing model: $model"
+            ollama pull "$model"
+          else
+            echo "Model already exists: $model"
+          fi
+        done
       shell: bash


### PR DESCRIPTION
This PR enables specifying multiple models (space-separated) to pull and run in a single job.  

### Changes:  
- Accept space-separated model names (e.g., `qwen3:4b qwen3:0.6b`)  
- Pull models **one-by-one** using a loop  
- Only pull models **not already cached** (checked via `ollama list`)  
  
Let me know if you'd like adjustments! @samuelcolvin 